### PR TITLE
Use the same type in marshal and unmarshal

### DIFF
--- a/secrets.go
+++ b/secrets.go
@@ -280,7 +280,7 @@ func checksum(b []byte) ([]byte, error) {
 func unmarshalPayload(mp []byte, p *encryptedPayload) error {
 	b := bytes.NewBuffer(mp)
 
-	var ln int32
+	var ln uint32
 	if err := binary.Read(b, binary.BigEndian, &ln); err != nil {
 		return err
 	}


### PR DESCRIPTION
We marshal the length of the ciphertext as a uint32, but we were unmarshaling it as an int32. I think this would only be a problem if the length of the ciphertext was larger than math.MaxInt32.

In that case we'd likely get a panic when trying to call `make` with a negative number.